### PR TITLE
Fix build for new agent & update the build scripts a bit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ MAINTAINER The Stripe Observability Team <support@stripe.com>
 
 RUN apt-get update && apt-get install -y build-essential python-dev python-pip python-virtualenv curl
 RUN DD_API_KEY='foo' DD_INSTALL_ONLY=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)"
+RUN mkdir /src
+ADD requirements.txt requirements-test.txt Makefile /src/
+RUN make -C /src test-requirements
 
 ADD . /src
+
 CMD make -C /src test install

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,15 @@ install:
 	cp -Rp ./checks.d /build
 	cp -Rp ./conf.d /build
 
-test:
+/src/venv:
 	virtualenv /src/venv
+
+test-requirements: /src/venv requirements.txt requirements-test.txt
 	/src/venv/bin/pip install -r requirements.txt
 	/src/venv/bin/pip install -r requirements-test.txt
+
+test: test-requirements
 	ln -sf /src/checks.d/* /opt/datadog-agent/agent/checks.d/
 	sh -c '. /src/venv/bin/activate ; env PYTHONPATH=$(echo $PYTHONPATH):/opt/datadog-agent/agent nosetests tests/checks/integration/test_file.py'
 
-.PHONY: test install
+.PHONY: test-requirements test install

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,6 @@ test-requirements: /src/venv requirements.txt requirements-test.txt
 
 test: test-requirements
 	ln -sf /src/checks.d/* /opt/datadog-agent/agent/checks.d/
-	sh -c '. /src/venv/bin/activate ; env PYTHONPATH=$(echo $PYTHONPATH):/opt/datadog-agent/agent nosetests tests/checks/integration/test_file.py'
+	sh -c '. /src/venv/bin/activate ; env PYTHONPATH=$(echo $PYTHONPATH):/opt/datadog-agent/agent nosetests tests/checks/integration/test_*.py'
 
 .PHONY: test-requirements test install

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,5 @@ nose==1.3.4
 flake8==2.5.1
 mock==1.0.1
 pep8==1.5.7
+python-etcd==0.4.3
+python-consul==0.6.0


### PR DESCRIPTION
I stumbled across a few problems trying to run tests in Docker myself, so I fixed them. Collected changes:

* Pull in etcd and consul python modules, as required by the new agent checks
* Run all available integration tests, not just `test_file.py`
* Allow `pip install` results to be docker-cached; this speeds up test runs (especially interactive ones) by a lot.

Build seems to be passing, so I'd say this might be good to go. Agree, @gphat? (: