### PR TITLE
Monitor Storm via the REST API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
+INSTALL_DIRS = checks.d conf.d venv scripts lib
+
 install:
 	mkdir -p /build
-	cp -Rp ./checks.d /build
-	cp -Rp ./conf.d /build
+	for dir in ${INSTALL_DIRS} ; do cp -Rp $$dir /build ; done
 
 /src/venv:
 	virtualenv /src/venv
@@ -12,9 +13,9 @@ test-requirements: /src/venv requirements.txt requirements-test.txt
 
 test: test-requirements
 	ln -sf /src/checks.d/* /opt/datadog-agent/agent/checks.d/
-	sh -c '. /src/venv/bin/activate ; env PYTHONPATH=$(echo $PYTHONPATH):/opt/datadog-agent/agent nosetests tests/checks/integration/test_*.py'
+	sh -c '. /src/venv/bin/activate ; env PYTHONPATH=$(echo $PYTHONPATH):/opt/datadog-agent/agent nosetests tests/checks/integration/test_*.py tests/lib/test_*.py'
 
 dockertest:
-	docker build -t localbuild . && docker run --rm -ti localbuild:latest make -C /src test
+	docker build -t localbuild . && docker run --rm -ti localbuild:latest make -C /src test install
 
 .PHONY: dockertest test-requirements test install

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,7 @@ test: test-requirements
 	ln -sf /src/checks.d/* /opt/datadog-agent/agent/checks.d/
 	sh -c '. /src/venv/bin/activate ; env PYTHONPATH=$(echo $PYTHONPATH):/opt/datadog-agent/agent nosetests tests/checks/integration/test_*.py'
 
-.PHONY: test-requirements test install
+dockertest:
+	docker build -t localbuild . && docker run --rm -ti localbuild:latest make -C /src test
+
+.PHONY: dockertest test-requirements test install

--- a/checks.d/storm_rest_api.py
+++ b/checks.d/storm_rest_api.py
@@ -1,0 +1,293 @@
+# Add lib/ to the import path:
+import sys
+import os
+agent_lib_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.insert(1, agent_lib_dir)
+
+# stdlib
+from collections import namedtuple
+import urlparse
+import json
+import time
+import sys
+
+# 3p
+import requests
+
+# project
+from checks import AgentCheck
+from util import headers
+import re
+import storm_utils
+
+
+StormConfig = namedtuple(
+    'StormConfig',
+    [
+        'metric_prefix',
+        'tags',
+        'task_tags',
+        'timeout',
+        'executor_details_whitelist',
+        'topology_timeout',
+        'url',
+        'topologies',
+        'cache_file',
+        'cache_staleness',
+    ]
+)
+
+class StormRESTCheck(AgentCheck):
+    class ConnectionFailure(StandardError):
+        def __init__(self, url, timeout):
+            self.url = url
+            self.timeout = timeout
+
+    DEFAULT_TIMEOUT = 5 # seconds
+    DEFAULT_STALENESS=240 # seconds
+
+    def instance_config(self, instance):
+        url = instance.get('url')
+        if url is None:
+            raise Exception("An url must be specified in the instance")
+
+        cache_file = instance.get('cache_file')
+        if cache_file is None:
+            raise Exception("You must specify a cache file (querying the storm API synchronously is too slow).")
+
+        timeout = instance.get('timeout', self.DEFAULT_TIMEOUT)
+        topology_timeout = instance.get('topology_timeout', timeout)
+        topologies_re = re.compile(instance.get('topologies', '(.*)'))
+
+        task_tags_from_json = {}
+        tag_file = instance.get('task_tags_file', None)
+        if tag_file is not None:
+            with open(tag_file, 'r') as f:
+                task_tags_from_json = json.load(f)
+        task_tags = instance.get('task_tags', {}).copy()
+        task_tags.update(task_tags_from_json)
+
+        raw_whitelist = set(instance.get('executor_details_whitelist', []))
+        executor_details_whitelist = [re.compile(regex) for regex in raw_whitelist]
+
+        return StormConfig(
+            metric_prefix=instance.get('metric_prefix', None),
+            url=url,
+            timeout=timeout,
+            topology_timeout=topology_timeout,
+            tags=instance.get('tags', []),
+            executor_details_whitelist=executor_details_whitelist,
+            task_tags=task_tags,
+            cache_file=cache_file,
+            cache_staleness=instance.get('cache_staleness', self.DEFAULT_STALENESS),
+            topologies=topologies_re,
+        )
+
+    def metric(self, config, name):
+        if config.metric_prefix is not None:
+            return "%s.storm.rest.%s" % (config.metric_prefix, name)
+        else:
+            return "storm.rest.%s" % name
+
+    def check(self, instance):
+        config = self.instance_config(instance)
+
+        check_status = AgentCheck.OK
+        check_msg = 'Everything went well'
+        check_tags = [
+            'url:' + config.url,
+        ] + config.tags
+
+        details = None
+        with open(config.cache_file, 'r') as cache_f:
+            details = json.load(cache_f)
+
+        oldest_acceptable_cache_time = time.time() - config.cache_staleness
+        if details['status'] == 'success' and details['updated'] > oldest_acceptable_cache_time:
+            data = details['data']
+            self.report_cluster(config, data['cluster'])
+            self.report_supervisors(config, data['supervisors'])
+            self.report_topologies(config, data['topologies'])
+            for topology_detail in data['topology_details']:
+                self.report_topology(config, topology_detail['name'], topology_detail['topology'])
+                for executor_details in topology_detail['component_details']:
+                    self.report_executor_details(config, executor_details)
+        else:
+            check_status = AgentCheck.CRITICAL
+            if details['status'] != 'success':
+                check_msg = "Could not connect to URL %s with timeout %d" % (failure.url, failure.timeout)
+            else:
+                check_msg = "Cache is too stale: %d vs. expected minimum %d" % (details['updated'], oldest_acceptable_cache_time)
+
+        self.service_check(
+            self.metric(config, 'cached_data_ok'),
+            check_status,
+            message=check_msg,
+            tags=check_tags)
+
+    def report_cluster(self, config, cluster):
+        self.gauge(self.metric(config, 'cluster.nimbus_uptime_seconds'),
+                   storm_utils.translate_timespec(cluster['nimbusUptime']),
+                   tags=config.tags)
+        self.gauge(self.metric(config, 'cluster.slots_used_count'),
+                   cluster['slotsUsed'],
+                   tags=config.tags)
+        self.gauge(self.metric(config, 'cluster.supervisor_count'),
+                   cluster['supervisors'],
+                   tags=config.tags)
+        self.gauge(self.metric(config, 'cluster.slots_total_count'),
+                   cluster['slotsTotal'],
+                   tags=config.tags)
+        self.gauge(self.metric(config, 'cluster.slots_free_count'),
+                   cluster['slotsFree'],
+                   tags=config.tags)
+        self.gauge(self.metric(config, 'cluster.executors_total_count'),
+                   cluster['executorsTotal'],
+                   tags=config.tags)
+        self.gauge(self.metric(config, 'cluster.tasks_total_count'),
+                   cluster['tasksTotal'],
+                   tags=config.tags)
+
+
+    def report_supervisors(self, config, resp):
+        self.gauge(self.metric(config, 'supervisors_total'),
+                   len(resp.get('supervisors', [])),
+                   tags=config.tags)
+        for supe in resp.get('supervisors', []):
+            supe_tags = [
+                'storm_host:' + supe.get('host'),
+            ] + config.tags
+            self.gauge(self.metric(config, 'supervisor.slots_total'),
+                       supe.get('slotsTotal'), tags=supe_tags)
+            self.gauge(self.metric(config, 'supervisor.slots_used_total'),
+                       supe.get('slotsUsed'), tags=supe_tags)
+            self.gauge(self.metric(config, 'supervisor.uptime_seconds'),
+                       storm_utils.translate_timespec(supe.get('uptime')), tags=supe_tags)
+
+    def _topology_name(self, config, topology):
+        """Returns the name if a config's topology regex matches, None otherwise."""
+        match = config.topologies.match(topology.get('name'))
+        if match:
+            return match.group(1)
+        else:
+            return None
+
+    def report_topologies(self, config, topologies):
+        """Report metadata about topologies that match the topologies regex.
+        """
+        for pretty_name, topo in topologies.iteritems():
+            uptime = topo.get('uptime', '0s')
+            tags = config.tags + [
+                'storm_topology:' + pretty_name,
+            ]
+            self.gauge(self.metric(config, 'topologies.uptime_seconds'),
+                       storm_utils.translate_timespec(uptime), tags=tags)
+            self.gauge(self.metric(config, 'topologies.tasks_total'),
+                       topo['tasksTotal'], tags=tags)
+            self.gauge(self.metric(config, 'topologies.workers_total'),
+                       topo['workersTotal'], tags=tags)
+            self.gauge(self.metric(config, 'topologies.executors_total'), topo['executorsTotal'], tags=tags)
+
+    def task_id_tags(self, config, component_type, task_id):
+        return config.task_tags.get(component_type, {}).get(task_id, [])
+
+    def report_topology(self, config, name, details):
+        """
+        Report statistics for a single topology's spouts and bolts.
+        """
+        tags = config.tags + [
+            'storm_topology:' + name,
+        ]
+        def report_task(component_type, name, task, tags):
+            self.gauge(self.metric(config, ('%s.executors_total' % component_type)),
+                       task['executors'], task_tags)
+            self.gauge(self.metric(config, ('%s.tasks_total' % component_type)),
+                       task['tasks'], task_tags)
+
+            self.gauge(self.metric(config, ('%s.emitted_total' % component_type)),
+                       task['emitted'], task_tags)
+            self.gauge(self.metric(config, ('%s.transferred_total' % component_type)),
+                       task['transferred'], task_tags)
+            self.gauge(self.metric(config, ('%s.acked_total' % component_type)),
+                       task['acked'], task_tags)
+            self.gauge(self.metric(config, ('%s.failed_total' % component_type)),
+                       task['failed'], task_tags)
+
+        ## Report spouts
+        for spout in details.get('spouts'):
+            name = spout['spoutId']
+            task_tags = tags + self.task_id_tags(config, 'spout', name) + [
+                'storm_component_type:spout',
+                'storm_task_id:' + name,
+            ]
+            report_task('spout', name, spout, task_tags)
+            self.gauge(self.metric(config, 'spout.complete_latency_ms'),
+                       float(spout['completeLatency']) * 1000, task_tags)
+
+        for bolt in details.get('bolts'):
+            name = bolt['boltId']
+            task_tags = tags + self.task_id_tags(config, 'bolt', name) + [
+                'storm_component_type:bolt',
+                'storm_task_id:' + name,
+            ]
+            report_task('bolt', name, bolt, task_tags)
+            if bolt['executed'] is not None:
+                executed_count = bolt['executed']
+            else:
+                executed_count = 0
+            self.gauge(self.metric(config, 'bolt.executed_total'),
+                       executed_count, task_tags)
+            self.gauge(self.metric(config, 'bolt.execute_latency_ms'),
+                       float(bolt['executeLatency']) * 1000, task_tags)
+            self.gauge(self.metric(config, 'bolt.process_latency_ms'),
+                       float(bolt['processLatency']) * 1000, task_tags)
+            self.gauge(self.metric(config, 'bolt.capacity_percent'),
+                       float(bolt['capacity']) * 100, task_tags)
+
+    def report_executor_details(self, config, details):
+        """
+        Report statistics for a single topology's task ID's executors.
+        """
+
+        topology_name = self._topology_name(config, details)
+        name = details['id']
+        task_type = details['componentType']
+        tags = config.tags + self.task_id_tags(config, task_type, name) + [
+            'storm_topology:' + topology_name,
+            'storm_component_type:' + task_type,
+            'storm_task_id:' + details['id'],
+        ]
+        self.gauge(self.metric(config, 'executor.executors_total'),
+                               details['executors'], tags=tags)
+        self.gauge(self.metric(config, 'executor.tasks_total'),
+                               details['executors'], tags=tags)
+
+        # Embarrassingly, executorStats are undocumented in the REST
+        # API docs (so we might not be allowed to rely on them). But
+        # they're the only way to get some SERIOUSLY useful metrics -
+        # per-host metrics, in particular.
+        for executor in details['executorStats']:
+            executor_tags = tags + [
+                'executor_id:' + executor['id'],
+                'storm_host:' + executor['host'],
+                'storm_port:' + str(executor['port']),
+            ]
+            self.gauge(self.metric(config, 'executor.emitted_total'),
+                       executor.get('emitted', 0), tags=executor_tags)
+            self.gauge(self.metric(config, 'executor.transferred_total'),
+                       executor.get('transferred', 0), tags=executor_tags)
+            self.gauge(self.metric(config, 'executor.acked_total'),
+                       executor.get('acked', 0), tags=executor_tags)
+            self.gauge(self.metric(config, 'executor.executed_total'),
+                       executor.get('executed', 0), tags=executor_tags)
+            self.gauge(self.metric(config, 'executor.failed_total'),
+                       executor.get('failed', 0), tags=executor_tags)
+            self.gauge(self.metric(config, 'executor.execute_latency_ms'),
+                       float(executor.get('executeLatency', 0)) * 1000, tags=executor_tags)
+            self.gauge(self.metric(config, 'executor.process_latency_ms'),
+                       float(executor.get('processLatency', 0)) * 1000, tags=executor_tags)
+
+            self.gauge(self.metric(config, 'executor.capacity_percent'),
+                       float(executor.get('capacity', 0)) * 100, tags=executor_tags)
+            self.gauge(self.metric(config, 'executor.uptime_seconds'),
+                       storm_utils.translate_timespec(executor.get('uptime', '0s')), tags=executor_tags)

--- a/conf.d/storm_rest_api.yaml.example
+++ b/conf.d/storm_rest_api.yaml.example
@@ -1,0 +1,31 @@
+---
+# init_config:
+# # None needed for this check
+#
+# instances:
+#  - topologies: "(.*)"             # regex applied to instance IDs to extract the name
+#    url: "http://127.0.0.1:8080"   # (required) The storm REST API endpoint
+#    cache_file: "/tmp/foo.json"    # (required) A JSON file prepopulated by scripts/cache-storm-data.
+#                                   # Each cache file must be unique to each instance.
+#    cache_staleness: 240           # Age in seconds that the cache file contents are allowed to
+#                                   # be out of date.
+#    timeout: 5                     # seconds; defaults to 5
+#    topology_timeout: 5            # seconds; this can take a long time; defaults to "timeout"
+#    tags:                          # additional tags applied to metrics
+#      - "storm_topology_purpose:frob"
+#    metric_prefix: null            # If non-null, this prefix will be prepended to all metric
+#                                   # and service check names
+#    task_tags:
+#      spout: {}                    # A dictionary of storm task ID -> list of tags to add to
+#                                   # metrics reported about that task
+#      bolt: {}                     # ditto
+#    task_tags_file: null           # If non-nil, a JSON file of the same format as task_tags
+#                                   # that additional tags will be read from every time the
+#                                   # check runs.
+#    executor_details_whitelist: [] # Regexes for task IDs for which we request executor details
+#                                   # from storm. Each of these can take a long time to retrieve,
+#                                   # so use sparingly.
+
+init_config: {}
+
+instances: []

--- a/lib/storm_utils.py
+++ b/lib/storm_utils.py
@@ -1,0 +1,53 @@
+import re
+
+TIMESPEC_RE = re.compile('^(\d+)([a-z])$')
+
+def translate_timespec(string):
+    """Parses a storm duration-ish timespec like "5m 20s" and returns the
+    corresponding number of seconds.
+    """
+    components = string.split(' ')
+    time_translator = {
+        'w': 60*60*24*7,
+        'd': 60*60*24,
+        'h': 60*60,
+        'm': 60,
+        's': 1,
+    }
+    res = 0
+    for component in components:
+        if component == '':
+            continue
+        match = TIMESPEC_RE.match(component)
+        if match is None:
+            raise ValueError("Can't parse the timespec", string, 'component=', component)
+        multiplier = time_translator[match.group(2)]
+        number = int(match.group(1))
+        res += multiplier * number
+    return res
+
+
+def _topology_name(topology_re, topology):
+    """Returns the name if a config's topology regex matches, None otherwise."""
+    match = topology_re.match(topology.get('name'))
+    if match:
+        return match.group(1)
+    else:
+        return None
+
+def collect_topologies(topology_re, topologies):
+    """
+    Filter out topologies matching the regex, and collect the newest ACTIVE one.
+    Returns a dictionary of the form `{taggable_name: topology}`
+    """
+    ret = dict()
+    for topo in topologies:
+        name = _topology_name(topology_re, topo)
+        # Skip if the topology name doesn't match the ones we want:
+        if name is None or topo.get('status', 'KILLED') != 'ACTIVE':
+            continue
+        if name not in ret:
+            ret[name] = []
+        ret[name].append(topo)
+    topo_key = lambda x: translate_timespec(x['uptime'])
+    return {name: sorted(value, key=topo_key)[0] for name, value in ret.iteritems()}

--- a/scripts/cache-storm-data
+++ b/scripts/cache-storm-data
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+
+# This script uses the storm_rest_api config, queries each configured
+# storm instance, and writes the responses to a one json file per
+# instance.
+
+# Add lib/ to the import path:
+import sys
+import os
+agent_lib_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../lib')
+sys.path.insert(1, agent_lib_dir)
+
+from collections import namedtuple
+import urlparse
+import json
+import re
+import tempfile
+import os
+import sys
+import time
+
+import requests
+import yaml
+
+import storm_utils
+
+StormConfig = namedtuple(
+    'StormConfig',
+    [
+        'url',
+        'timeout',
+        'topology_timeout',
+        'topologies',
+        'executor_details_whitelist',
+        'cache_file',
+    ]
+)
+
+class StormCache:
+    class ConnectionFailure(StandardError):
+        def __init__(self, url, timeout):
+            self.url = url
+            self.timeout = timeout
+
+    TIMESPEC_RE = re.compile('^(\d+)([a-z])$')
+
+    def __init__(self, conf_file):
+        with open(conf_file, 'r') as conf:
+            self.instances = yaml.load(conf).get('instances', [])
+
+    def instance_config(self, instance):
+        timeout = instance.get('timeout', 5)
+        raw_whitelist = instance.get('executor_details_whitelist', [])
+        executor_details_whitelist = [re.compile(regex) for regex in raw_whitelist]
+        topologies_re = re.compile(instance.get('topologies', '(.*)'))
+        return StormConfig(
+            url=instance['url'],
+            timeout=timeout,
+            topology_timeout=instance.get('topology_timeout', timeout),
+            cache_file=instance.get('cache_file'),
+            executor_details_whitelist=executor_details_whitelist,
+            topologies=topologies_re,
+        )
+
+    def _get_json_from_url(self, config, base_url, timeout=None):
+        if timeout is None:
+            timeout = config.timeout
+        url = urlparse.urljoin(config.url, base_url)
+        try:
+            resp = requests.get(url, timeout=timeout)
+            resp.raise_for_status()
+            return resp.json()
+        except:
+            raise self.ConnectionFailure(url, timeout)
+
+    def is_detail_task_id(self, config, task_id):
+        for regex in config.executor_details_whitelist:
+            if regex.match(task_id):
+                return True
+        return False
+
+    def collect_detail_components(self, config, details):
+        detail_ids=[]
+        for spout in details.get('spouts'):
+            if self.is_detail_task_id(config, spout['spoutId']):
+                detail_ids.append(spout['encodedSpoutId'])
+        for bolt in details.get('bolts'):
+            name = bolt['boltId']
+            if self.is_detail_task_id(config, bolt['boltId']):
+                detail_ids.append(bolt['encodedBoltId'])
+        return detail_ids
+
+
+    def cache_one(self, config):
+        try:
+            cluster = self._get_json_from_url(config, '/api/v1/cluster/summary')
+            supervisors = self._get_json_from_url(config, '/api/v1/supervisor/summary')
+            all_topologies = self._get_json_from_url(config, '/api/v1/topology/summary')
+            topologies = storm_utils.collect_topologies(config.topologies, all_topologies.get('topologies'))
+            topology_url = urlparse.urljoin(config.url, '/api/v1/topology/')
+            topology_details = []
+            for name, topology in topologies.iteritems():
+                this_topology_url = urlparse.urljoin(topology_url, topology['id'])
+                details = self._get_json_from_url(config, this_topology_url, timeout=config.topology_timeout)
+                executor_components = self.collect_detail_components(config, details)
+                executor_details = []
+                for component in executor_components:
+                    detail_url = urlparse.urljoin(urlparse.urljoin(this_topology_url + '/', 'component/'), component)
+                    executor_details.append(self._get_json_from_url(config, detail_url, timeout=config.timeout))
+                topology_details.append({
+                    'name': name,
+                    'topology': details,
+                    'component_details': executor_details,
+                })
+
+            return {
+                'status': 'success',
+                'updated': time.time(),
+                'data': {
+                    'cluster': cluster,
+                    'supervisors': supervisors,
+                    'topologies': topologies,
+                    'topology_details': topology_details,
+                },
+            }
+        except self.ConnectionFailure as failure:
+            return {
+                'status': 'error',
+                'error_url': failure.url,
+                'error_timeout': failure.timeout,
+                'updated': time.time(),
+            }
+
+    def run(self):
+        for instance in self.instances:
+            config = self.instance_config(instance)
+            if config.cache_file is None:
+                continue
+            cached = self.cache_one(config)
+            with tempfile.NamedTemporaryFile(prefix=config.cache_file, delete=False) as tmp:
+                json.dump(cached, tmp)
+                os.rename(tmp.name, config.cache_file)
+
+if __name__ == '__main__':
+    StormCache(sys.argv[1]).run()

--- a/tests/checks/integration/test_storm_rest_api.py
+++ b/tests/checks/integration/test_storm_rest_api.py
@@ -1,0 +1,355 @@
+# project
+from checks import AgentCheck
+from tests.checks.common import AgentCheckTest, load_check
+
+class TestFileUnit(AgentCheckTest):
+    CHECK_NAME='storm_rest_api'
+
+    def assert_tags(self, expected_tags, present_tags):
+        for tag in expected_tags:
+            self.assertTrue(tag in present_tags,
+                            "Expected tags\n%s\n and present tags\n%s\n do not match" % (expected_tags, present_tags))
+
+    def find_metric(self, metrics, name, tags=[]):
+        tags_to_find = set(tags)
+        found_metrics = (metric for metric in metrics if metric[0] == name and tags_to_find <= set(metric[3].get('tags', [])))
+        return next(found_metrics)
+
+    def test_metric_name_with_prefix(self):
+        instance = {'url': 'http://localhost:8080', 'timeout': 0, 'metric_prefix': 'foo', "cache_file": "/dev/null"}
+        conf = {
+            'init_config': {},
+            'instances': [ instance ]
+        }
+        self.check = load_check('storm_rest_api', conf, {})
+        self.assertEqual('foo.storm.rest.baz', self.check.metric(self.check.instance_config(instance), 'baz'))
+
+    def test_metric_name_without_prefix(self):
+        instance = {'url': 'http://localhost:8080', 'timeout': 0, "cache_file": "/dev/null"}
+        conf = {
+            'init_config': {},
+            'instances': [instance]
+        }
+        self.check = load_check('storm_rest_api', conf, {})
+        self.assertEqual('storm.rest.baz', self.check.metric(self.check.instance_config(instance), 'baz'))
+
+    def test_cluster(self):
+        uptime = "22h 41m 49s"
+        cluster = {
+            "stormVersion":"0.9.3",
+            "nimbusUptime": uptime,
+            "supervisors":7,
+            "slotsTotal":147,
+            "slotsUsed":7,
+            "slotsFree":140,
+            "executorsTotal":11415,
+            "tasksTotal":11415
+        }
+        instance = {'url': 'http://localhost:8080', 'timeout': 0, 'tags': ['cluster_want:form'], "cache_file": "/dev/null"}
+        conf = {
+            'init_config': {},
+            'instances': [instance]
+        }
+        self.check = load_check('storm_rest_api', conf, {})
+        self.check.report_cluster(self.check.instance_config(instance), cluster)
+        metrics = self.check.get_metrics()
+
+        cluster_uptime = self.find_metric(metrics, 'storm.rest.cluster.nimbus_uptime_seconds')
+        self.assertEqual(81709, cluster_uptime[2])
+        self.assert_tags(['cluster_want:form'], cluster_uptime[3]['tags'])
+
+        cluster_slots_used = self.find_metric(metrics, 'storm.rest.cluster.slots_used_count')
+        self.assertEqual(7, cluster_slots_used[2])
+        print cluster_slots_used
+        self.assert_tags(['cluster_want:form'], cluster_slots_used[3]['tags'])
+
+        for metric_name in ['supervisor_count', 'slots_total_count', 'slots_free_count', 'executors_total_count', 'tasks_total_count']:
+            metric = self.find_metric(metrics, 'storm.rest.cluster.%s' % metric_name)
+            self.assert_tags(['cluster_want:form'], metric[3]['tags'])
+            self.assertTrue(metric[2] > 0)
+
+
+    def test_supervisors(self):
+        instance = {'url': 'http://localhost:8080', 'timeout': 0, "cache_file": "/dev/null"}
+        conf = {
+            'init_config': {},
+            'instances': [instance]
+        }
+        self.check = load_check('storm_rest_api', conf, {})
+        supervisors = {"supervisors":[
+            {"id":"cb91ebc3-8212-43d4-bad2-75da548ee00b","host":"10.100.8.142","uptime":"1d 1h 28m 37s","slotsTotal":21,"slotsUsed":0},
+            {"id":"56768ca7-07e9-485d-aa0e-63d42a70fbbb","host":"10.100.40.149","uptime":"8h 54m 32s","slotsTotal":21,"slotsUsed":1},
+            {"id":"f8db3c29-c65e-4004-9da5-89f449965b88","host":"10.100.29.85","uptime":"1d 1h 29m 27s","slotsTotal":21,"slotsUsed":1},
+            {"id":"ddab8e08-195c-4759-87ff-bafd31306326","host":"10.100.41.184","uptime":"1d 1h 29m 34s","slotsTotal":21,"slotsUsed":1}]}
+
+        self.check.report_supervisors(self.check.instance_config(instance), supervisors)
+        metrics = self.check.get_metrics()
+        self.assertEqual(1 + 4*3, len(metrics))
+
+    def test_topologies(self):
+        instance = {'url': 'http://localhost:8080', 'timeout': 0, 'topologies': '^(sometopo)_.*$', "cache_file": "/dev/null"}
+        conf = {
+            'init_config': {},
+            'instances': [
+                instance
+            ],
+        }
+        self.check = load_check('storm_rest_api', conf, {})
+        collected_topos = {
+            "sometopo": {"id":"sometopo_987IMDEAD6798a-3-1464117779","encodedId":"sometopo_987IMDEAD6798a-3-1464117779","name":"sometopo_987IMDEAD6798a","status":"KILLED","uptime":"10s","tasksTotal":11366,"workersTotal":7,"executorsTotal":11366},
+        }
+        self.check.report_topologies(self.check.instance_config(instance), collected_topos)
+        metrics = self.check.get_metrics()
+        self.assertTrue(len(metrics) > 0)
+
+        uptime_metric = self.find_metric(metrics, 'storm.rest.topologies.uptime_seconds')
+        self.assertEqual(10, uptime_metric[2])
+        self.assert_tags(['storm_topology:sometopo'], uptime_metric[3]['tags'])
+
+        executors_metric = self.find_metric(metrics, 'storm.rest.topologies.executors_total')
+        self.assertEqual(11366, executors_metric[2])
+        self.assert_tags(['storm_topology:sometopo'], executors_metric[3]['tags'])
+
+    def test_topology_details(self):
+        topology_from_sum = {"id":"sometopo_987IENien9887a-3-1464117779","encodedId":"sometopo_987IENien9887a-3-1464117779","name":"sometopo_987IENien9887a","status":"ACTIVE","uptime":"30s","tasksTotal":11366,"workersTotal":7,"executorsTotal":11366}
+        name = 'sometopo'
+        topology_details = {
+            "spouts": [
+                {"executors": 48, "emitted": 0, "errorLapsedSecs": 13822, "completeLatency": "2.030", "transferred": 50, "acked": 40, "errorPort": 6711, "spoutId": "somespout", "tasks": 48, "errorHost": "", "lastError": "", "errorWorkerLogLink": "", "failed": 20, "encodedSpoutId": "somespout"},
+                {"executors": 48, "emitted": 0, "errorLapsedSecs": 13822, "completeLatency": "2.030", "transferred": 50, "acked": 40, "errorPort": 6711, "spoutId": "detailspout", "tasks": 48, "errorHost": "", "lastError": "", "errorWorkerLogLink": "", "failed": 20, "encodedSpoutId": "detailspout"}
+            ],
+            "bolts": [
+                {"executors": 3, "emitted": 10, "errorLapsedSecs": None, "transferred": 12, "acked": 9, "errorPort": "", "executeLatency": "2.300", "tasks": 4, "executed": 12, "processLatency": "2.501", "boltId": "somebolt", "errorHost": "", "lastError": "", "errorWorkerLogLink": "", "capacity": "0.020", "failed": 2, "encodedBoltId": "somebolt"},
+                {"executors": 3, "emitted": 10, "errorLapsedSecs": None, "transferred": 12, "acked": 3, "errorPort": "", "executeLatency": "2.300", "tasks": 4, "executed": 12, "processLatency": "2.501", "boltId": "detail::bolt", "errorHost": "", "lastError": "", "errorWorkerLogLink": "", "capacity": "0.020", "failed": 2, "encodedBoltId": "detail%3A%3Abolt"}
+
+            ]
+        }
+        instance = {
+            'url': 'http://localhost:8080',
+            'timeout': 0,
+            'topologies': '^(sometopo)_.*$',
+            'executor_details_whitelist': ['detailspout', 'detail::bolt'],
+            'task_tags': {
+                'spout': {
+                    'somespout': [
+                        'is_a_great_spout:true'
+                    ]
+                },
+                'bolt': {
+                    'somebolt': [
+                        'is_a_great_bolt:true'
+                    ]
+                }
+            },
+            "cache_file": "/dev/null"
+        }
+        conf = {
+            'init_config': {},
+            'instances': [
+                instance
+            ],
+        }
+        self.check = load_check('storm_rest_api', conf, {})
+
+        self.check.report_topology(self.check.instance_config(instance), name, topology_details)
+
+        metrics = self.check.get_metrics()
+        spout_workers_metric = self.find_metric(metrics, 'storm.rest.spout.executors_total', ['storm_task_id:somespout'])
+        self.assertEqual(48, spout_workers_metric[2])
+        print spout_workers_metric[3]
+        self.assert_tags(['storm_topology:sometopo', 'storm_task_id:somespout', 'is_a_great_spout:true'], spout_workers_metric[3]['tags'])
+
+        complete_latency_metric = self.find_metric(metrics, 'storm.rest.spout.complete_latency_ms', ['storm_task_id:somespout'])
+        self.assertEqual(2030, round(complete_latency_metric[2]))
+
+        bolt_workers_metric = self.find_metric(metrics, 'storm.rest.bolt.executors_total', ['storm_task_id:somebolt'])
+        self.assertEqual(3, bolt_workers_metric[2])
+        self.assert_tags(['storm_topology:sometopo', 'storm_task_id:somebolt', 'is_a_great_bolt:true'], bolt_workers_metric[3]['tags'])
+
+        bolt_executed_metric = self.find_metric(metrics, 'storm.rest.bolt.executed_total', ['storm_task_id:somebolt'])
+        self.assertEqual(12, bolt_executed_metric[2])
+        self.assert_tags(['storm_topology:sometopo', 'storm_task_id:somebolt', 'is_a_great_bolt:true'], bolt_workers_metric[3]['tags'])
+
+    def test_executor_metrics_for_bolt(self):
+        data = {
+            "executors": 72,
+            "componentErrors": [],
+            "encodedId": "detail%3A%3Abold",
+            "boltStats":[
+                {"emitted":0,"windowPretty":"10m 0s","transferred":0,"acked":0,"executeLatency":"0.000","executed":0,"processLatency":"0.000","window":"600","failed":0}
+                ,{"emitted":0,"windowPretty":"3h 0m 0s","transferred":0,"acked":0,"executeLatency":"0.000","executed":0,"processLatency":"0.000","window":"10800","failed":0}
+            ],
+            "topologyId": "a_topology-6-1464634734",
+            "name": "a_topology_8Y1e7Vi5fIvwSp",
+            "executorStats": [
+                {
+                    "workerLogLink": "http://10.100.14.0:8000/log?file=worker-6710.log",
+                    "emitted": 0,
+                    "port": 6710,
+                    "transferred": 0,
+                    "host": "10.100.14.0",
+                    "acked": 0,
+                    "uptime": "4m 0s",
+                    "encodedId": "%5B10751-10751%5D",
+                    "executeLatency": "0",
+                    "executed": 15,
+                    "processLatency": "0",
+                    "capacity": "0.000",
+                    "id": "[10751-10751]",
+                    "failed": 0
+                },
+                {
+                    "workerLogLink": "http://10.100.29.85:8000/log?file=worker-6711.log",
+                    "emitted": 0,
+                    "port": 6711,
+                    "transferred": 0,
+                    "host": "10.100.29.85",
+                    "acked": 0,
+                    "uptime": "2m 32s",
+                    "encodedId": "%5B10752-10752%5D",
+                    "executeLatency": "0.000",
+                    "executed": 4,
+                    "processLatency": "0.000",
+                    "capacity": "0.000",
+                    "id": "[10752-10752]",
+                    "failed": 0
+                }],
+            "tasks": 72,
+            "window": "600",
+            "inputStats": [],
+            "componentType": "bolt",
+            "windowHint": "10m 0s",
+            "encodedTopologyId": "a_topology-6-1464634734",
+            "id": "detail::bolt",
+            "outputStats": []
+        }
+        instance = {
+            'url': 'http://localhost:8080',
+            'timeout': 0,
+            'topologies': '^(a_topology)_.*$',
+            'executor_details_whitelist': ['detail::bolt'],
+            'task_tags': {
+                'bolt': {
+                    'detail::bolt': [
+                        'is_a_great_bolt:true'
+                    ]
+                }
+            },
+            "cache_file": "/dev/null"
+        }
+        conf = {
+            'init_config': {},
+            'instances': [
+                instance
+            ],
+        }
+        self.check = load_check('storm_rest_api', conf, {})
+        self.check.report_executor_details(self.check.instance_config(instance), data)
+        self.check.report_executor_details(self.check.instance_config(instance), data)
+        metrics = self.check.get_metrics()
+        executor_count = self.find_metric(metrics, 'storm.rest.executor.executors_total')
+        self.assertEqual(72, executor_count[2])
+        self.assert_tags(['storm_task_id:detail::bolt', 'storm_component_type:bolt', 'storm_topology:a_topology', 'is_a_great_bolt:true'], executor_count[3]['tags'])
+
+        executed_counts_1 = self.find_metric(metrics, 'storm.rest.executor.executed_total', ['storm_host:10.100.29.85'])
+        executed_counts_2 = self.find_metric(metrics, 'storm.rest.executor.executed_total', ['storm_host:10.100.14.0'])
+        self.assertEqual(4, executed_counts_1[2])
+        self.assertEqual(15, executed_counts_2[2])
+        self.assert_tags(['storm_task_id:detail::bolt', 'storm_component_type:bolt', 'storm_topology:a_topology', 'is_a_great_bolt:true'], executed_counts_2[3]['tags'])
+        uptime_1 = self.find_metric(metrics, 'storm.rest.executor.uptime_seconds', ['storm_host:10.100.29.85'])
+        uptime_2 = self.find_metric(metrics, 'storm.rest.executor.uptime_seconds', ['storm_host:10.100.14.0'])
+        self.assertEqual(152, uptime_1[2])
+        self.assertEqual(240, uptime_2[2])
+
+
+
+    def test_executor_metrics_for_spout(self):
+        data = {
+            "executors": 72,
+            "componentErrors": [],
+            "encodedId": "detail%3A%3Aspout",
+            "spoutSummary": [{"windowPretty": "10m 0s", "window": "600", "emitted": 0, "transferred": 0, "completeLatency": "0.000", "acked": 0, "failed": 0},
+                             {"windowPretty": "3h 0m 0s", "window": "10800", "emitted": 0, "transferred": 0, "completeLatency": "0.000", "acked": 0, "failed": 0},
+            ],
+            "topologyId": "a_topology-6-1464634734",
+            "name": "a_topology_8Y1e7Vi5fIvwSp",
+            "executorStats": [
+                {
+                    "workerLogLink": "http://10.100.14.0:8000/log?file=worker-6710.log",
+                    "emitted": 0,
+                    "port": 6710,
+                    "transferred": 0,
+                    "host": "10.100.14.0",
+                    "acked": 0,
+                    "uptime": "4m 0s",
+                    "encodedId": "%5B10751-10751%5D",
+                    "executeLatency": "0",
+                    "executed": 15,
+                    "processLatency": "0",
+                    "capacity": "0.000",
+                    "id": "[10751-10751]",
+                    "failed": 0
+                },
+                {
+                    "workerLogLink": "http://10.100.29.85:8000/log?file=worker-6711.log",
+                    "emitted": 0,
+                    "port": 6711,
+                    "transferred": 0,
+                    "host": "10.100.29.85",
+                    "acked": 0,
+                    "uptime": "2m 32s",
+                    "encodedId": "%5B10752-10752%5D",
+                    "executeLatency": "0.000",
+                    "executed": 4,
+                    "processLatency": "0.000",
+                    "capacity": "0.000",
+                    "id": "[10752-10752]",
+                    "failed": 0
+                }],
+            "tasks": 72,
+            "window": "600",
+            "inputStats": [],
+            "componentType": "spout",
+            "windowHint": "10m 0s",
+            "encodedTopologyId": "a_topology-6-1464634734",
+            "id": "detail::spout",
+            "outputStats": []
+        }
+        instance = {
+            'url': 'http://localhost:8080',
+            'timeout': 0,
+            'topologies': '^(a_topology)_.*$',
+            'executor_details_whitelist': ['detail::spout'],
+            'task_tags': {
+                'spout': {
+                    'detail::spout': [
+                        'is_a_great_spout:true'
+                    ]
+                }
+            },
+            "cache_file": "/dev/null"
+        }
+        conf = {
+            'init_config': {},
+            'instances': [
+                instance
+            ],
+        }
+        self.check = load_check('storm_rest_api', conf, {})
+        self.check.report_executor_details(self.check.instance_config(instance), data)
+        self.check.report_executor_details(self.check.instance_config(instance), data)
+        metrics = self.check.get_metrics()
+        executor_count = self.find_metric(metrics, 'storm.rest.executor.executors_total')
+        self.assertEqual(72, executor_count[2])
+        self.assert_tags(['storm_task_id:detail::spout', 'storm_component_type:spout', 'storm_topology:a_topology', 'is_a_great_spout:true'], executor_count[3]['tags'])
+
+        executed_counts_1 = self.find_metric(metrics, 'storm.rest.executor.executed_total', ['storm_host:10.100.29.85'])
+        executed_counts_2 = self.find_metric(metrics, 'storm.rest.executor.executed_total', ['storm_host:10.100.14.0'])
+        self.assertEqual(4, executed_counts_1[2])
+        self.assertEqual(15, executed_counts_2[2])
+        self.assert_tags(['storm_task_id:detail::spout', 'storm_component_type:spout', 'storm_topology:a_topology', 'is_a_great_spout:true'], executed_counts_1[3]['tags'])
+
+        uptime_1 = self.find_metric(metrics, 'storm.rest.executor.uptime_seconds', ['storm_host:10.100.29.85'])
+        uptime_2 = self.find_metric(metrics, 'storm.rest.executor.uptime_seconds', ['storm_host:10.100.14.0'])
+        self.assertEqual(152, uptime_1[2])
+        self.assertEqual(240, uptime_2[2])

--- a/tests/lib/test_storm_utils.py
+++ b/tests/lib/test_storm_utils.py
@@ -1,0 +1,41 @@
+# Add lib/ to the import path:
+import sys
+import os
+agent_lib_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../lib')
+sys.path.insert(1, agent_lib_dir)
+
+# stdlib
+import re
+
+# test
+import unittest
+
+# unit under test
+import storm_utils
+
+class TestStormUtils(unittest.TestCase):
+    def test_timespec(self):
+        self.assertEqual(330, storm_utils.translate_timespec('5m 30s'))
+        self.assertEqual(1728331, storm_utils.translate_timespec('20d 5m 31s'))
+        self.assertEqual(12114041, storm_utils.translate_timespec('20w 5h 41s'))
+        self.assertEqual(0, storm_utils.translate_timespec(''))
+        with self.assertRaises(ValueError) as context:
+            storm_utils.translate_timespec('20--')
+        with self.assertRaises(ValueError) as context:
+            storm_utils.translate_timespec('20Y 5m 3s')
+
+
+    def test_collect_topologies(self):
+        topologies_re = re.compile('^(sometopo)_.*$')
+
+        topologies = {"topologies":[
+            {"id":"sometopo_8VmCP0bp6W21qr-2-1464115959","encodedId":"sometopo_8VmCP0bp6W21qr-2-1464115959","name":"sometopo_8VmCP0bp6W21qr","status":"ACTIVE","uptime":"1d 1h 38m 13s","tasksTotal":11366,"workersTotal":7,"executorsTotal":11366},
+            {"id":"sometopo_987IENien9887a-3-1464117779","encodedId":"sometopo_987IENien9887a-3-1464117779","name":"sometopo_987IENien9887a","status":"ACTIVE","uptime":"30s","tasksTotal":11366,"workersTotal":7,"executorsTotal":11366},
+            {"id":"sometopo_987IMDEAD6798a-3-1464117779","encodedId":"sometopo_987IMDEAD6798a-3-1464117779","name":"sometopo_987IMDEAD6798a","status":"KILLED","uptime":"10s","tasksTotal":11366,"workersTotal":7,"executorsTotal":11366},
+            {"id":"some-other-topo_8VmCP0bp6W21qr-2-1464115959","encodedId":"some-other-topo_8VmCP0bp6W21qr-2-1464115959","name":"some-other-topo_8VmCP0bp6W21qr","status":"ACTIVE","uptime":"2s","tasksTotal":5972,"workersTotal":7,"executorsTotal":5972}
+        ]}
+        collected_topos = storm_utils.collect_topologies(topologies_re, topologies['topologies'])
+
+        # the interesting one:
+        topo = collected_topos.get('sometopo')
+        self.assertEqual(topo['id'], 'sometopo_987IENien9887a-3-1464117779')


### PR DESCRIPTION
# What's this PR do?

This adds `storm_rest_api.py` (and tests), a check that crawls Storm 0.9's REST API interface, and reports metrics from that. The great thing about this one is that it includes metrics you don't see anywhere else (neither the built-in metrics consumers nor the Thrift interface report the capacity, for example).

# What is left to do?

- [x] Add a thing to add custom per-storm task ID tags from a json file
- [x] fix any questionable python (-:
- [x] see if we can turn down the check interval for this one - it takes 22s to retrieve the topology details.