### PR TITLE
Add Hadoop Resource Manager Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,15 @@ Each plugin here is provided with a sample config file containing some documenta
 
 Here's our list of checks!
 
-## Resque
+## Hadoop Resource Manager
 
-Fetches metrics about processed jobs from Resque. It's pretty minimal, but we only needed it for a small thing.
+Leverages Stripe's Hadoop Job Tracker [Timberlake](https://github.com/stripe/timberlake) in conjunction with Hadoop's
+own metrics to generate mapreduce metrics:
+
+* `data.mapreduce.jobs.pending` tagged with `reduce` or `map`
+* `data.mapreduce.jobs.running` tagged with `reduce` or `map`
+* `data.mapreduce.vcores`
+* `data.mapreduce.nodes` tagged with `active` or `lost`
 
 ## Jenkins Metrics
 

--- a/checks.d/hadoop_resourcemanager.py
+++ b/checks.d/hadoop_resourcemanager.py
@@ -1,0 +1,77 @@
+import requests
+
+from checks import AgentCheck
+import collections
+
+
+class HadoopResourceManager(AgentCheck):
+    DEFAULT_TIMEOUT = 1
+    CONNECT_CHECK_NAME = 'hadoop_resourcemanager.can_connect'
+
+    def check(self, instance):
+        if 'url' not in instance:
+            self.log.info("Skipping instance, no url found.")
+            return
+
+        if 'resourcemanager_url' not in instance:
+            self.log.info("Skipping instance no resourcemanager_url found.")
+            return
+
+        instance_tags = instance.get('tags', [])
+        timeout = self.init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
+        job_tracker_resp = self.get_json(instance['url'] + "/jobs/", timeout)
+        resourcemanager_resp = self.get_json(instance['resourcemanager_url'] + "/ws/v1/cluster/metrics", timeout)
+
+        jobs = filter(lambda item: item['details']['state'] == 'RUNNING', job_tracker_resp)
+
+        metrics = collections.Counter(
+            maps_pending=0,
+            maps_running=0,
+            reduces_pending=0,
+            reduces_running=0,
+        )
+        for j in jobs:
+            if j['details']['mapProgress'] < 100:
+                metrics['maps_running'] += j['details']['mapsRunning']
+                metrics['maps_pending'] += j['details']['mapsPending']
+            else:
+                metrics['reduces_running'] += j['details']['reducesRunning']
+                metrics['reduces_pending'] += j['details']['reducesPending']
+
+        self.gauge('data.mapreduce.jobs.running', metrics['maps_running'], tags=instance_tags + ['job_type:map'])
+        self.gauge('data.mapreduce.jobs.running', metrics['reduces_running'], tags=instance_tags + ['job_type:reduce'])
+        self.gauge('data.mapreduce.jobs.pending', metrics['maps_pending'], tags=instance_tags + ['job_type:map'])
+        self.gauge('data.mapreduce.jobs.pending', metrics['reduces_pending'], tags=instance_tags + ['job_type:reduce'])
+
+        self.gauge('data.mapreduce.vcores',  resourcemanager_resp['clusterMetrics']['totalVirtualCores'], tags=instance_tags)
+        self.gauge('data.mapreduce.nodes',  resourcemanager_resp['clusterMetrics']['activeNodes'], tags=instance_tags + ['status=active'])
+        self.gauge('data.mapreduce.nodes',  resourcemanager_resp['clusterMetrics']['lostNodes'], tags=instance_tags + ['status=lost'])
+
+    def get_json(self, url, timeout):
+        try:
+            r = requests.get(url, timeout=timeout, headers={'accept': 'application/json'})
+            r.raise_for_status()
+        except requests.exceptions.Timeout:
+            # If there's a timeout
+            self.service_check(
+                self.CONNECT_CHECK_NAME, AgentCheck.CRITICAL,
+                message='%s timed out after %s seconds.' % (url, timeout),
+                tags=["url:{0}".format(url)]
+            )
+            raise Exception("Timeout when hitting %s" % url)
+
+        except requests.exceptions.HTTPError:
+            self.service_check(
+                self.CONNECT_CHECK_NAME, AgentCheck.CRITICAL,
+                message='%s returned a status of %s' % (url, r.status_code),
+                tags=["url:{0}".format(url)]
+            )
+            raise Exception("Got %s when hitting %s" % (r.status_code, url))
+
+        else:
+            self.service_check(
+                self.CONNECT_CHECK_NAME, AgentCheck.OK,
+                tags=["url:{0}".format(url)]
+            )
+
+        return r.json()

--- a/conf.d/hadoop_resourcemanager.yaml.example
+++ b/conf.d/hadoop_resourcemanager.yaml.example
@@ -1,0 +1,8 @@
+# This check takes no init_config
+init_config:
+
+# The job tracker to connect to.
+instances:
+  - url: http://localhost:5656
+    resourcemanager_url: http://localhost:8088
+    tags: []


### PR DESCRIPTION
### What's this PR do?
Adds support for tracking map reduce jobs by way of Timberlake and Hadoop.

### Motivation
To replace an internal dashboard and metrics collected via cron jobs.

cc @jbalogh 