### PR TITLE
Don't scale microsecond storm latency metrics

### DIFF
--- a/checks.d/storm_rest_api.py
+++ b/checks.d/storm_rest_api.py
@@ -221,8 +221,8 @@ class StormRESTCheck(AgentCheck):
                 'storm_task_id:' + name,
             ]
             report_task('spout', name, spout, task_tags)
-            self.gauge(self.metric(config, 'spout.complete_latency_ms'),
-                       float(spout['completeLatency']) * 1000, task_tags)
+            self.gauge(self.metric(config, 'spout.complete_latency_us'),
+                       float(spout['completeLatency']), task_tags)
 
         for bolt in details.get('bolts'):
             name = bolt['boltId']
@@ -237,10 +237,10 @@ class StormRESTCheck(AgentCheck):
                 executed_count = 0
             self.gauge(self.metric(config, 'bolt.executed_total'),
                        executed_count, task_tags)
-            self.gauge(self.metric(config, 'bolt.execute_latency_ms'),
-                       float(bolt['executeLatency']) * 1000, task_tags)
-            self.gauge(self.metric(config, 'bolt.process_latency_ms'),
-                       float(bolt['processLatency']) * 1000, task_tags)
+            self.gauge(self.metric(config, 'bolt.execute_latency_us'),
+                       float(bolt['executeLatency']), task_tags)
+            self.gauge(self.metric(config, 'bolt.process_latency_us'),
+                       float(bolt['processLatency']), task_tags)
             self.gauge(self.metric(config, 'bolt.capacity_percent'),
                        float(bolt['capacity']) * 100, task_tags)
 
@@ -282,10 +282,10 @@ class StormRESTCheck(AgentCheck):
                        executor.get('executed', 0), tags=executor_tags)
             self.gauge(self.metric(config, 'executor.failed_total'),
                        executor.get('failed', 0), tags=executor_tags)
-            self.gauge(self.metric(config, 'executor.execute_latency_ms'),
-                       float(executor.get('executeLatency', 0)) * 1000, tags=executor_tags)
-            self.gauge(self.metric(config, 'executor.process_latency_ms'),
-                       float(executor.get('processLatency', 0)) * 1000, tags=executor_tags)
+            self.gauge(self.metric(config, 'executor.execute_latency_us'),
+                       float(executor.get('executeLatency', 0)), tags=executor_tags)
+            self.gauge(self.metric(config, 'executor.process_latency_us'),
+                       float(executor.get('processLatency', 0)), tags=executor_tags)
 
             self.gauge(self.metric(config, 'executor.capacity_percent'),
                        float(executor.get('capacity', 0)) * 100, tags=executor_tags)

--- a/tests/checks/integration/test_storm_rest_api.py
+++ b/tests/checks/integration/test_storm_rest_api.py
@@ -159,8 +159,8 @@ class TestFileUnit(AgentCheckTest):
         print spout_workers_metric[3]
         self.assert_tags(['storm_topology:sometopo', 'storm_task_id:somespout', 'is_a_great_spout:true'], spout_workers_metric[3]['tags'])
 
-        complete_latency_metric = self.find_metric(metrics, 'storm.rest.spout.complete_latency_ms', ['storm_task_id:somespout'])
-        self.assertEqual(2030, round(complete_latency_metric[2]))
+        complete_latency_metric = self.find_metric(metrics, 'storm.rest.spout.complete_latency_us', ['storm_task_id:somespout'])
+        self.assertEqual(2.030, complete_latency_metric[2])
 
         bolt_workers_metric = self.find_metric(metrics, 'storm.rest.bolt.executors_total', ['storm_task_id:somebolt'])
         self.assertEqual(3, bolt_workers_metric[2])


### PR DESCRIPTION
# What

This PR renames the latency metrics we get from storm to reflect the real unit that it reports: microseconds, and gets rid of scaling.

# Why

We were scaling them up by 1000, thinking they were seconds & hoping to report milliseconds. Neither of this is right.

# Test plan

Tried this in QA, and the numbers look far more realistic now!