### PR TITLE
Count processed tuples monotonically

### DIFF
--- a/checks.d/storm_rest_api.py
+++ b/checks.d/storm_rest_api.py
@@ -204,13 +204,13 @@ class StormRESTCheck(AgentCheck):
             self.gauge(self.metric(config, ('%s.tasks_total' % component_type)),
                        task['tasks'], task_tags)
 
-            self.gauge(self.metric(config, ('%s.emitted_total' % component_type)),
+            self.monotonic_count(self.metric(config, ('%s.emitted_total' % component_type)),
                        task['emitted'], task_tags)
-            self.gauge(self.metric(config, ('%s.transferred_total' % component_type)),
+            self.monotonic_count(self.metric(config, ('%s.transferred_total' % component_type)),
                        task['transferred'], task_tags)
-            self.gauge(self.metric(config, ('%s.acked_total' % component_type)),
+            self.monotonic_count(self.metric(config, ('%s.acked_total' % component_type)),
                        task['acked'], task_tags)
-            self.gauge(self.metric(config, ('%s.failed_total' % component_type)),
+            self.monotonic_count(self.metric(config, ('%s.failed_total' % component_type)),
                        task['failed'], task_tags)
 
         ## Report spouts
@@ -235,7 +235,7 @@ class StormRESTCheck(AgentCheck):
                 executed_count = bolt['executed']
             else:
                 executed_count = 0
-            self.gauge(self.metric(config, 'bolt.executed_total'),
+            self.monotonic_count(self.metric(config, 'bolt.executed_total'),
                        executed_count, task_tags)
             self.gauge(self.metric(config, 'bolt.execute_latency_us'),
                        float(bolt['executeLatency']), task_tags)
@@ -272,16 +272,17 @@ class StormRESTCheck(AgentCheck):
                 'storm_host:' + executor['host'],
                 'storm_port:' + str(executor['port']),
             ]
-            self.gauge(self.metric(config, 'executor.emitted_total'),
+            self.monotonic_count(self.metric(config, 'executor.emitted_total'),
                        executor.get('emitted', 0), tags=executor_tags)
-            self.gauge(self.metric(config, 'executor.transferred_total'),
+            self.monotonic_count(self.metric(config, 'executor.transferred_total'),
                        executor.get('transferred', 0), tags=executor_tags)
-            self.gauge(self.metric(config, 'executor.acked_total'),
+            self.monotonic_count(self.metric(config, 'executor.acked_total'),
                        executor.get('acked', 0), tags=executor_tags)
-            self.gauge(self.metric(config, 'executor.executed_total'),
+            self.monotonic_count(self.metric(config, 'executor.executed_total'),
                        executor.get('executed', 0), tags=executor_tags)
-            self.gauge(self.metric(config, 'executor.failed_total'),
+            self.monotonic_count(self.metric(config, 'executor.failed_total'),
                        executor.get('failed', 0), tags=executor_tags)
+
             self.gauge(self.metric(config, 'executor.execute_latency_us'),
                        float(executor.get('executeLatency', 0)), tags=executor_tags)
             self.gauge(self.metric(config, 'executor.process_latency_us'),

--- a/checks.d/storm_rest_api.py
+++ b/checks.d/storm_rest_api.py
@@ -115,7 +115,7 @@ class StormRESTCheck(AgentCheck):
         else:
             check_status = AgentCheck.CRITICAL
             if details['status'] != 'success':
-                check_msg = "Could not connect to URL %s with timeout %d" % (failure.url, failure.timeout)
+                check_msg = "Could not connect to URL %s with timeout %d" % (details['error_url'], details['error_timeout'])
             else:
                 check_msg = "Cache is too stale: %d vs. expected minimum %d" % (details['updated'], oldest_acceptable_cache_time)
 

--- a/tests/checks/integration/test_storm_rest_api.py
+++ b/tests/checks/integration/test_storm_rest_api.py
@@ -152,6 +152,7 @@ class TestFileUnit(AgentCheckTest):
         self.check = load_check('storm_rest_api', conf, {})
 
         self.check.report_topology(self.check.instance_config(instance), name, topology_details)
+        self.check.report_topology(self.check.instance_config(instance), name, topology_details)
 
         metrics = self.check.get_metrics()
         spout_workers_metric = self.find_metric(metrics, 'storm.rest.spout.executors_total', ['storm_task_id:somespout'])
@@ -167,7 +168,7 @@ class TestFileUnit(AgentCheckTest):
         self.assert_tags(['storm_topology:sometopo', 'storm_task_id:somebolt', 'is_a_great_bolt:true'], bolt_workers_metric[3]['tags'])
 
         bolt_executed_metric = self.find_metric(metrics, 'storm.rest.bolt.executed_total', ['storm_task_id:somebolt'])
-        self.assertEqual(12, bolt_executed_metric[2])
+        self.assertEqual(0, bolt_executed_metric[2])
         self.assert_tags(['storm_topology:sometopo', 'storm_task_id:somebolt', 'is_a_great_bolt:true'], bolt_workers_metric[3]['tags'])
 
     def test_executor_metrics_for_bolt(self):
@@ -253,8 +254,8 @@ class TestFileUnit(AgentCheckTest):
 
         executed_counts_1 = self.find_metric(metrics, 'storm.rest.executor.executed_total', ['storm_host:10.100.29.85'])
         executed_counts_2 = self.find_metric(metrics, 'storm.rest.executor.executed_total', ['storm_host:10.100.14.0'])
-        self.assertEqual(4, executed_counts_1[2])
-        self.assertEqual(15, executed_counts_2[2])
+        self.assertEqual(0, executed_counts_1[2])
+        self.assertEqual(0, executed_counts_2[2])
         self.assert_tags(['storm_task_id:detail::bolt', 'storm_component_type:bolt', 'storm_topology:a_topology', 'is_a_great_bolt:true'], executed_counts_2[3]['tags'])
         uptime_1 = self.find_metric(metrics, 'storm.rest.executor.uptime_seconds', ['storm_host:10.100.29.85'])
         uptime_2 = self.find_metric(metrics, 'storm.rest.executor.uptime_seconds', ['storm_host:10.100.14.0'])
@@ -345,8 +346,8 @@ class TestFileUnit(AgentCheckTest):
 
         executed_counts_1 = self.find_metric(metrics, 'storm.rest.executor.executed_total', ['storm_host:10.100.29.85'])
         executed_counts_2 = self.find_metric(metrics, 'storm.rest.executor.executed_total', ['storm_host:10.100.14.0'])
-        self.assertEqual(4, executed_counts_1[2])
-        self.assertEqual(15, executed_counts_2[2])
+        self.assertEqual(0, executed_counts_1[2])
+        self.assertEqual(0, executed_counts_2[2])
         self.assert_tags(['storm_task_id:detail::spout', 'storm_component_type:spout', 'storm_topology:a_topology', 'is_a_great_spout:true'], executed_counts_1[3]['tags'])
 
         uptime_1 = self.find_metric(metrics, 'storm.rest.executor.uptime_seconds', ['storm_host:10.100.29.85'])


### PR DESCRIPTION
We were emitting them as gauges before, but that's incorrect - the tuples come in as a total over the lifetime of the topology (which means we probably want monotonic counters). This PR adjusts that.

(Also, fix error reporting as my tests in QA revealed that the cache job can in fact error out (-:)